### PR TITLE
adding ArgumentTypeInfos.registerByClass to SubCommandArgumentType.init

### DIFF
--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/commands/SubCommandArgumentType.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/commands/SubCommandArgumentType.java
@@ -15,6 +15,7 @@ import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.synchronization.ArgumentTypeInfo;
+import net.minecraft.commands.synchronization.ArgumentTypeInfos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -122,11 +123,12 @@ public class SubCommandArgumentType implements ArgumentType<String> {
         event.register(ForgeRegistries.Keys.COMMAND_ARGUMENT_TYPES, helper -> {
             helper.register(new ResourceLocation("imm_ptl:sub_command_argument_type"), new CustomArgumentTypeInfo());
         });
+        ArgumentTypeInfos.registerByClass(SubCommandArgumentType.class, new CustomArgumentTypeInfo());
 //        ArgumentTypeRegistry.registerArgumentType( //TODO @Nick1st Check if that registration procedure is correct
 //            new ResourceLocation("imm_ptl:sub_command_argument_type"),
 //            SubCommandArgumentType.class,
 //            new CustomArgumentTypeInfo()
 //        );
-        
+
     }
 }


### PR DESCRIPTION
I found that attempting to run a world with cheats will immediately disconnect you after loading. Upon further inspection, I found that it's required to both use RegisterEvent.register and ArgumentTypeInfos.registerByClass to register argument types. This PR implements this,