### PR TITLE
Fix structures spawning in void dimension

### DIFF
--- a/src/main/java/qouteall/imm_ptl/peripheral/alternate_dimension/AlternateDimensions.java
+++ b/src/main/java/qouteall/imm_ptl/peripheral/alternate_dimension/AlternateDimensions.java
@@ -1,6 +1,7 @@
 package qouteall.imm_ptl.peripheral.alternate_dimension;
 
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceKey;
@@ -180,7 +181,7 @@ public class AlternateDimensions {
         Registry<StructureSet> structureSets = rm.registryOrThrow(Registry.STRUCTURE_SET_REGISTRY);
         
         FlatLevelGeneratorSettings flatChunkGeneratorConfig =
-            new FlatLevelGeneratorSettings(Optional.empty(), biomeRegistry);
+            new FlatLevelGeneratorSettings(Optional.of(HolderSet.direct()), biomeRegistry);
         flatChunkGeneratorConfig.getLayersInfo().add(new FlatLayerInfo(1, Blocks.AIR));
         flatChunkGeneratorConfig.updateLayers();
         


### PR DESCRIPTION
Currently, structures such as villages spawn in the void dimension provided by this mod. This is caused by the empty optional being passed into the `FlatLevelGeneratorSettings` constructor. If the optional isn't present, as it is not with `Optional.empty()` being passed in, `ChunkGenerator` falls back to a default structure set rather than using an empty structure overrides list as is intended.

This fix is already in the latest Fabric version, as seen here:

https://github.com/iPortalTeam/ImmersivePortalsMod/blob/55c9c1e7e298e09d8d43b0114e64e30271aa43b6/src/main/java/qouteall/imm_ptl/peripheral/alternate_dimension/AlternateDimensions.java#L179

Since this fix is not in this or the latest Forge branch, it should probably be cherrypicked into that branch as well.