### PR TITLE
[1.19.2] Updated Oculus & Rubidium to fix #128

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,14 @@ allprojects {
         maven {
             url = "https://modmaven.dev/"
         }
+        maven {
+            name "aether"
+            url = "https://maven.pkg.github.com/The-Aether-Team/The-Aether"
+            credentials {
+                username "$mavenDownUser"
+                password "$mavenDownPassword"
+            }
+        }
 
         flatDir {
             dirs 'deps'
@@ -99,7 +107,7 @@ allprojects {
         runtimeOnly fg.deobf("curse.maven:mcjtylib-233105:4372084")
 
         // Dimension Sync broken report?
-        runtimeOnly fg.deobf("curse.maven:aether-255308:${aether_fileid}")
+        runtimeOnly fg.deobf("com.aetherteam.aether:aether:${aether_version}")
 
         // Curios (required by Aether)
         runtimeOnly fg.deobf("curse.maven:curios-309927:4834339")

--- a/build.gradle
+++ b/build.gradle
@@ -53,14 +53,6 @@ allprojects {
         maven {
             url = "https://modmaven.dev/"
         }
-        maven {
-            name "aether"
-            url = "https://maven.pkg.github.com/Gilded-Games/The-Aether"
-            credentials {
-                username "$mavenDownUser"
-                password "$mavenDownPassword"
-            }
-        }
 
         flatDir {
             dirs 'deps'
@@ -107,7 +99,10 @@ allprojects {
         runtimeOnly fg.deobf("curse.maven:mcjtylib-233105:4372084")
 
         // Dimension Sync broken report?
-        runtimeOnly fg.deobf("com.gildedgames.aether:aether:1.19.2-0.2.0")
+        runtimeOnly fg.deobf("curse.maven:aether-255308:${aether_fileid}")
+
+        // Curios (required by Aether)
+        runtimeOnly fg.deobf("curse.maven:curios-309927:4834339")
     }
 
     minecraft {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=false
 org.gradle.daemon=false
 
 # Mod Properties
-mod_version=2.3.5
+mod_version=2.3.6
 maven_group=qouteall
 archives_base_name=immersive-portals
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ mapping_version=2022.11.06
 loader_version=43.2.4
 
 # Dependencies
-aether_fileid=4816885
+aether_version=1.19.2-1.0.0-beta.1.3-forge
 pehkui_version=3.6.0-1.19.2-forge
 #twilightforest_version=4.1.999
 twilightforest_fileid=4337394

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,13 +16,14 @@ mapping_version=2022.11.06
 loader_version=43.2.4
 
 # Dependencies
+aether_fileid=4816885
 pehkui_version=3.6.0-1.19.2-forge
 #twilightforest_version=4.1.999
 twilightforest_fileid=4337394
 # public release integrated into create
 flywheel_version=0.6.8-11
-rubidium_fileid=3973894
-oculus_fileid=4299147
+rubidium_fileid=4763255
+oculus_fileid=4763262
 curios_version=1.19.2-5.1.1.0
 #tconstruct_fileid=3829979 // 1.19.2 in the works
 #mantle_fileid=3829975 // ^

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinIrisIris.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinIrisIris.java
@@ -2,6 +2,7 @@ package qouteall.imm_ptl.core.compat.mixin;
 
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.shaderpack.DimensionId;
+import net.coderbot.iris.shaderpack.materialmap.NamespacedId;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -16,7 +17,7 @@ public class MixinIrisIris {
     @Inject(
         method = "getCurrentDimension", at = @At("HEAD"), cancellable = true
     )
-    private static void onGetCurrentDimension(CallbackInfoReturnable<DimensionId> cir) {
+    private static void onGetCurrentDimension(CallbackInfoReturnable<NamespacedId> cir) {
         if (IPCGlobal.renderer instanceof ExperimentalIrisPortalRenderer) {
             cir.setReturnValue(DimensionId.OVERWORLD);
         }

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinIrisSodiumChunkShaderInterface.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinIrisSodiumChunkShaderInterface.java
@@ -4,6 +4,7 @@ import net.coderbot.iris.compat.sodium.impl.shader_overrides.IrisChunkShaderInte
 import net.coderbot.iris.compat.sodium.impl.shader_overrides.ShaderBindingContextExt;
 import net.coderbot.iris.gl.blending.BlendModeOverride;
 import net.coderbot.iris.pipeline.SodiumTerrainPipeline;
+import net.coderbot.iris.uniforms.custom.CustomUniforms;
 import org.lwjgl.opengl.GL20C;
 import org.lwjgl.opengl.GL21;
 import org.spongepowered.asm.mixin.Mixin;
@@ -34,8 +35,8 @@ public class MixinIrisSodiumChunkShaderInterface {
     )
     private void onInit(
             int handle, ShaderBindingContextExt contextExt, SodiumTerrainPipeline pipeline,
-            boolean isShadowPass, BlendModeOverride blendModeOverride, float alpha,
-            CallbackInfo ci
+            boolean isShadowPass, BlendModeOverride blendModeOverride, List bufferOverrides,
+            float alpha, CustomUniforms customUniforms, CallbackInfo ci
     ) {
         ip_init(handle);
     }

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinIrisSodiumSodiumTerrainPipeline.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinIrisSodiumSodiumTerrainPipeline.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 @Pseudo
 @Mixin(value = SodiumTerrainPipeline.class, remap = false)
 public class MixinIrisSodiumSodiumTerrainPipeline {
-    @Inject(method = "getTerrainVertexShaderSource", at = @At("RETURN"), cancellable = true)
-    private void onGetTerrainVertexShaderSource(CallbackInfoReturnable<Optional<String>> cir) {
+    @Inject(method = "getTerrainSolidVertexShaderSource", at = @At("RETURN"), cancellable = true)
+    private void onGetTerrainSolidVertexShaderSource(CallbackInfoReturnable<Optional<String>> cir) {
         Optional<String> original = cir.getReturnValue();
         cir.setReturnValue(original.map(code ->
             ShaderCodeTransformation.transform(

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinIrisSodiumSodiumTerrainPipeline.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinIrisSodiumSodiumTerrainPipeline.java
@@ -1,12 +1,14 @@
 package qouteall.imm_ptl.core.compat.mixin;
 
 import com.mojang.blaze3d.shaders.Program;
+import me.jellysquid.mods.sodium.client.model.vertex.type.ChunkVertexType;
 import net.coderbot.iris.pipeline.SodiumTerrainPipeline;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import qouteall.imm_ptl.core.render.ShaderCodeTransformation;
 
 import java.util.Optional;
@@ -14,27 +16,40 @@ import java.util.Optional;
 @Pseudo
 @Mixin(value = SodiumTerrainPipeline.class, remap = false)
 public class MixinIrisSodiumSodiumTerrainPipeline {
-    @Inject(method = "getTerrainSolidVertexShaderSource", at = @At("RETURN"), cancellable = true)
-    private void onGetTerrainSolidVertexShaderSource(CallbackInfoReturnable<Optional<String>> cir) {
-        Optional<String> original = cir.getReturnValue();
-        cir.setReturnValue(original.map(code ->
-            ShaderCodeTransformation.transform(
-                Program.Type.VERTEX,
-                "iris_sodium_terrain_vertex",
-                code
-            )
-        ));
-    }
-    
-    @Inject(method = "getTranslucentVertexShaderSource", at = @At("RETURN"), cancellable = true)
-    private void onGetTranslucentVertexShaderSource(CallbackInfoReturnable<Optional<String>> cir) {
-        Optional<String> original = cir.getReturnValue();
-        cir.setReturnValue(original.map(code ->
-            ShaderCodeTransformation.transform(
-                Program.Type.VERTEX,
-                "iris_sodium_translucent_vertex",
-                code
-            )
-        ));
+    @Shadow
+    Optional<String> terrainSolidVertex;
+
+    @Shadow
+    Optional<String> terrainCutoutVertex;
+
+    @Shadow
+    Optional<String> translucentVertex;
+
+    @Inject(
+            method = "patchShaders",
+            at = @At("RETURN")
+    )
+    private void onPatchShaderEnds(ChunkVertexType vertexType, CallbackInfo ci) {
+        terrainSolidVertex = terrainSolidVertex.map(code ->
+                ShaderCodeTransformation.transform(
+                        Program.Type.VERTEX,
+                        "iris_sodium_terrain_vertex",
+                        code
+                )
+        );
+        terrainCutoutVertex = terrainCutoutVertex.map(code ->
+                ShaderCodeTransformation.transform(
+                        Program.Type.VERTEX,
+                        "iris_sodium_terrain_vertex",
+                        code
+                )
+        );
+        translucentVertex = translucentVertex.map(code ->
+                ShaderCodeTransformation.transform(
+                        Program.Type.VERTEX,
+                        "iris_sodium_terrain_vertex",
+                        code
+                )
+        );
     }
 }

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinSodiumChunkShaderInterface.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinSodiumChunkShaderInterface.java
@@ -27,15 +27,15 @@ public class MixinSodiumChunkShaderInterface {
     }
 
     @Inject(
-            method = "<init>",
-            at = @At("RETURN"),
-            require = 0,
-            remap = false
+        method = "<init>",
+        at = @At("RETURN"),
+        require = 0,
+        remap = false
     )
     private void onInit(
-            ShaderBindingContext context,
-            ChunkShaderOptions options,
-            CallbackInfo ci
+        ShaderBindingContext context,
+        ChunkShaderOptions options,
+        CallbackInfo ci
     ) {
         if (context instanceof GlObject glObject) {
             ip_init(glObject.handle());
@@ -45,25 +45,25 @@ public class MixinSodiumChunkShaderInterface {
     }
 
     @Inject(
-            method = "setup",
-            at = @At("RETURN"),
-            remap = false
+        method = "setup",
+        at = @At("RETURN"),
+        remap = false
     )
     private void onSetup(ChunkVertexType vertexType, CallbackInfo ci) {
         if (uIPClippingEquation != -1) {
             if (FrontClipping.isClippingEnabled) {
                 double[] equation = FrontClipping.getActiveClipPlaneEquationForEntities();
                 GL20C.glUniform4f(
-                        uIPClippingEquation,
-                        (float) equation[0],
-                        (float) equation[1],
-                        (float) equation[2],
-                        (float) equation[3]
+                    uIPClippingEquation,
+                    (float) equation[0],
+                    (float) equation[1],
+                    (float) equation[2],
+                    (float) equation[3]
                 );
             } else {
                 GL20C.glUniform4f(
-                        uIPClippingEquation,
-                        0, 0, 0, 1
+                    uIPClippingEquation,
+                    0, 0, 0, 1
                 );
             }
         }

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinSodiumChunkShaderInterface.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/mixin/MixinSodiumChunkShaderInterface.java
@@ -16,8 +16,8 @@ import qouteall.q_misc_util.Helper;
 @Pseudo
 @Mixin(targets = "me.jellysquid.mods.sodium.client.render.chunk.shader.ChunkShaderInterface", remap = false)
 public class MixinSodiumChunkShaderInterface {
-    private int uIPClippingEquation;
-    
+    private int uIPClippingEquation = -1;
+
     private void ip_init(int shaderId) {
         uIPClippingEquation = GL20C.glGetUniformLocation(shaderId, "imm_ptl_ClippingEquation");
         if (uIPClippingEquation < 0) {
@@ -25,42 +25,45 @@ public class MixinSodiumChunkShaderInterface {
             uIPClippingEquation = -1;
         }
     }
-    
+
     @Inject(
-        method = "<init>",
-        at = @At("RETURN"),
-        require = 0,
-        remap = false
+            method = "<init>",
+            at = @At("RETURN"),
+            require = 0,
+            remap = false
     )
     private void onInit(
-        ShaderBindingContext context,
-        ChunkShaderOptions options,
-        CallbackInfo ci
+            ShaderBindingContext context,
+            ChunkShaderOptions options,
+            CallbackInfo ci
     ) {
-        ip_init(((GlObject) context).handle());
+        if (context instanceof GlObject glObject) {
+            ip_init(glObject.handle());
+        } else {
+            Helper.log("Skipping sodium shader init injection");
+        }
     }
-    
+
     @Inject(
-        method = "setup",
-        at = @At("RETURN"),
-        remap = false
+            method = "setup",
+            at = @At("RETURN"),
+            remap = false
     )
     private void onSetup(ChunkVertexType vertexType, CallbackInfo ci) {
         if (uIPClippingEquation != -1) {
             if (FrontClipping.isClippingEnabled) {
                 double[] equation = FrontClipping.getActiveClipPlaneEquationForEntities();
                 GL20C.glUniform4f(
-                    uIPClippingEquation,
-                    (float) equation[0],
-                    (float) equation[1],
-                    (float) equation[2],
-                    (float) equation[3]
+                        uIPClippingEquation,
+                        (float) equation[0],
+                        (float) equation[1],
+                        (float) equation[2],
+                        (float) equation[3]
                 );
-            }
-            else {
+            } else {
                 GL20C.glUniform4f(
-                    uIPClippingEquation,
-                    0, 0, 0, 1
+                        uIPClippingEquation,
+                        0, 0, 0, 1
                 );
             }
         }


### PR DESCRIPTION
Hi this PR fixes #128 hope this helps,
best regards,
F0x

## List of changes
Bumped version to `1.3.6`
To fix the build/run:
  - Switched Aether to curse maven
  - Added Curios as dependency for Aether

Updated Oculus to `Oculus mc1.19.2-1.6.9`
Updated Rubidium to `Rubidium mc1.19.2-0.6.2c`

Fixed Sodium Mixin `getTerrainVertexShaderSource` -> `getTerrainSolidVertexShaderSource` 
Fixed Iris Mixin `init`
Fixed Iris Mixin `getCurrentDimension`

PS: Attached a zipped .jar for people to test/use
[immersive-portals-2.3.6-mc1.19.2-forge.zip](https://github.com/iPortalTeam/ImmersivePortalsModForForge/files/13400316/immersive-portals-2.3.6-mc1.19.2-forge.zip)