### PR TITLE
Fix datapack loading for 1.19

### DIFF
--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/portal/custom_portal_gen/CustomPortalGeneration.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/portal/custom_portal_gen/CustomPortalGeneration.java
@@ -49,7 +49,7 @@ public class CustomPortalGeneration {
     );
     
     public static ResourceKey<Registry<CustomPortalGeneration>> registryRegistryKey =
-        ResourceKey.createRegistryKey(new ResourceLocation("imm_ptl:custom_portal_generation"));
+        ResourceKey.createRegistryKey(new ResourceLocation("custom_portal_generation")); // Custom registry namespaces not enabled in forge
     
     public static final Codec<CustomPortalGeneration> codecV1 =
         RecordCodecBuilder.create(instance -> {

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/portal/custom_portal_gen/CustomPortalGeneration.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/portal/custom_portal_gen/CustomPortalGeneration.java
@@ -49,7 +49,7 @@ public class CustomPortalGeneration {
     );
     
     public static ResourceKey<Registry<CustomPortalGeneration>> registryRegistryKey =
-        ResourceKey.createRegistryKey(new ResourceLocation("custom_portal_generation")); // Custom registry namespaces not enabled in forge
+        ResourceKey.createRegistryKey(new ResourceLocation("custom_portal_generation")); // FORGE: Custom registry namespaces not enabled in forge
     
     public static final Codec<CustomPortalGeneration> codecV1 =
         RecordCodecBuilder.create(instance -> {


### PR DESCRIPTION
For issue #149.

While the first commit edits cross platform code, there is a Forge specific issue requiring it to be changed.

The second commit adds in the event listeners required for the conventional_dimension_change trigger.