### PR TITLE
[1.20.1] Add `canReachRaw` target for player block breaking mixin

### DIFF
--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/common/interaction/MixinServerPlayerGameMode.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/common/interaction/MixinServerPlayerGameMode.java
@@ -100,10 +100,16 @@ public class MixinServerPlayerGameMode {
     // disable distance check when doing cross-portal interaction
     @WrapOperation(
         method = "handleBlockBreakAction",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/server/level/ServerPlayer;canReach(Lnet/minecraft/core/BlockPos;D)Z"
-        ),
+        at = {
+            @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/server/level/ServerPlayer;canReach(Lnet/minecraft/core/BlockPos;D)Z"
+            ),
+            @At(
+                value = "INVOKE",
+                target = "net/minecraft/server/level/ServerPlayer;canReachRaw(Lnet/minecraft/core/BlockPos;D)Z"
+            )
+        },
         remap = false
     )
     private boolean wrapDistanceInHandleBlockBreakAction(ServerPlayer instance, BlockPos blockPos, double v, Operation<Boolean> original) {


### PR DESCRIPTION
- Fixes #240 when using Forge 47.4.2 - 47.2.9.

First of all, before anything else, I want to let you know that we've added our own workaround for Mixin injectors targetting `canReach` in Forge 47.4.10. However, I still think that addressing the issue on the modder's side may be useful in this scenario.

As I mentioned in the related issue, this is the "easy way" of fixing the bug I mentioned previously, to simply add `canReachRaw` as an injection point for the injector method.

Please see my issue comment (https://github.com/iPortalTeam/ImmersivePortalsModForForge/issues/240#issuecomment-3387824858) where I discuss this in more detail. Thanks!